### PR TITLE
MAINT: layout nitpick for row positioner widget

### DIFF
--- a/typhos/alarm.py
+++ b/typhos/alarm.py
@@ -329,7 +329,6 @@ class TyphosAlarm(TyphosObject, PyDMDrawing, _KindLevel, _AlarmLevel):
                     f'Updated alarm from {self.alarm_summary} to {new_alarm} '
                     f'on alarm widget with channel {self.channels()[0]}'
                 )
-
         self.alarm_summary = new_alarm
 
     def set_alarm_color(self, alarm_level):

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -11,7 +11,7 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets, uic
 
 from . import utils, widgets
-from .alarm import KindLevel, _KindLevel
+from .alarm import AlarmLevel, KindLevel, _KindLevel
 from .panel import SignalOrder, TyphosSignalPanel
 from .status import TyphosStatusThread
 
@@ -148,6 +148,14 @@ class TyphosPositionerWidget(
     _moving_attr = 'motor_is_moving'
     _error_message_attr = 'error_message'
     _min_visible_operation = 0.1
+
+    alarm_text = {
+        AlarmLevel.NO_ALARM: 'no alarm',
+        AlarmLevel.MINOR: 'minor',
+        AlarmLevel.MAJOR: 'major',
+        AlarmLevel.DISCONNECTED: 'no conn',
+        AlarmLevel.INVALID: 'invalid',
+    }
 
     def __init__(self, parent=None):
         self._moving = False
@@ -721,16 +729,10 @@ class TyphosPositionerWidget(
         Label the alarm circle with a short text bit.
         """
         alarms = self.ui.alarm_circle.AlarmLevel
-        if alarm_level == alarms.NO_ALARM:
-            text = 'no alarm'
-        elif alarm_level == alarms.MINOR:
-            text = 'minor'
-        elif alarm_level == alarms.MAJOR:
-            text = 'major'
-        elif alarm_level == alarms.DISCONNECTED:
-            text = 'no conn'
-        else:
-            text = 'invalid'
+        try:
+            text = self.alarm_text[alarm_level]
+        except KeyError:
+            text = self.alarm_text[alarms.INVALID]
         self.ui.alarm_label.setText(text)
 
     @property
@@ -790,6 +792,14 @@ class _TyphosPositionerRowUI(_TyphosPositionerUI):
 class TyphosPositionerRowWidget(TyphosPositionerWidget):
     ui: _TyphosPositionerRowUI
     ui_template = os.path.join(utils.ui_dir, "widgets", "positioner_row.ui")
+
+    alarm_text = {
+        AlarmLevel.NO_ALARM: 'ok',
+        AlarmLevel.MINOR: 'minor',
+        AlarmLevel.MAJOR: 'major',
+        AlarmLevel.DISCONNECTED: 'conn',
+        AlarmLevel.INVALID: 'inv',
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/typhos/ui/devices/BeckhoffAxis.detailed.ui
+++ b/typhos/ui/devices/BeckhoffAxis.detailed.ui
@@ -1,1 +1,335 @@
-BeckhoffAxis.embedded.ui
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>556</width>
+    <height>589</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>230</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="error_message_attribute" stdset="0">
+      <string>plc.status</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="signal_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="normal_tab">
+      <attribute name="title">
+       <string>Normal</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="normal_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="normal_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>528</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="normal_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="normal_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="config_tab">
+      <attribute name="title">
+       <string>Configuration</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="config_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="config_scroll">
+         <property name="font">
+          <font>
+           <underline>false</underline>
+          </font>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="config_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>528</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="config_panel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="config_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhos/ui/devices/BeckhoffAxis.detailed.ui
+++ b/typhos/ui/devices/BeckhoffAxis.detailed.ui
@@ -1,1 +1,1 @@
-PositionerBase.detailed.ui
+BeckhoffAxis.embedded.ui

--- a/typhos/ui/devices/BeckhoffAxis.embedded.ui
+++ b/typhos/ui/devices/BeckhoffAxis.embedded.ui
@@ -1,1 +1,100 @@
-PositionerBase.embedded.ui
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>872</width>
+    <height>228</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerRowWidget">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readback_attribute" stdset="0">
+      <string>user_readback</string>
+     </property>
+     <property name="setpoint_attribute" stdset="0">
+      <string>user_setpoint</string>
+     </property>
+     <property name="low_limit_switch_attribute" stdset="0">
+      <string>low_limit_switch</string>
+     </property>
+     <property name="high_limit_switch_attribute" stdset="0">
+      <string>high_limit_switch</string>
+     </property>
+     <property name="low_limit_travel_attribute" stdset="0">
+      <string>low_limit_travel</string>
+     </property>
+     <property name="high_limit_travel_attribute" stdset="0">
+      <string>high_limit_travel</string>
+     </property>
+     <property name="velocity_attribute" stdset="0">
+      <string>velocity</string>
+     </property>
+     <property name="acceleration_attribute" stdset="0">
+      <string>acceleration</string>
+     </property>
+     <property name="error_message_attribute" stdset="0">
+      <string>plc.status</string>
+     </property>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhos/ui/devices/BeckhoffAxis.embedded.ui
+++ b/typhos/ui/devices/BeckhoffAxis.embedded.ui
@@ -45,7 +45,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerRowWidget">
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
      <property name="toolTip">
       <string/>
      </property>

--- a/typhos/ui/devices/TwinCATStatePositioner.detailed.ui
+++ b/typhos/ui/devices/TwinCATStatePositioner.detailed.ui
@@ -1,1 +1,359 @@
-PositionerBase.detailed.ui
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>556</width>
+    <height>591</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>230</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readback_attribute" stdset="0">
+      <string>state</string>
+     </property>
+     <property name="setpoint_attribute" stdset="0">
+      <string>state</string>
+     </property>
+     <property name="low_limit_switch_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="high_limit_switch_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="low_limit_travel_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="high_limit_travel_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="velocity_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="acceleration_attribute" stdset="0">
+      <string/>
+     </property>
+     <property name="moving_attribute" stdset="0">
+      <string>busy</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="signal_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="normal_tab">
+      <attribute name="title">
+       <string>Normal</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="normal_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="normal_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>528</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="normal_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="normal_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="config_tab">
+      <attribute name="title">
+       <string>Configuration</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="config_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="config_scroll">
+         <property name="font">
+          <font>
+           <underline>false</underline>
+          </font>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="config_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>528</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="config_panel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="config_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhos/ui/devices/TwinCATStatePositioner.embedded.ui
+++ b/typhos/ui/devices/TwinCATStatePositioner.embedded.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>872</width>
-    <height>58</height>
+    <height>228</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -73,6 +73,9 @@
      <property name="acceleration_attribute" stdset="0">
       <string/>
      </property>
+     <property name="moving_attribute" stdset="0">
+      <string>busy</string>
+     </property>
      <property name="show_expert_button" stdset="0">
       <bool>true</bool>
      </property>
@@ -82,13 +85,13 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerRowWidget</class>
-   <extends>TyphosPositionerWidget</extends>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -49,22 +49,6 @@ TyphosBase PyDMLogDisplay > QPlainTextEdit {
     font: 10px normal;
 }
 
-TyphosBase TyphosPositionerWidget[moving="true"] .QFrame {
-    border: 2px solid yellow;
-}
-
-TyphosBase TyphosPositionerWidget[moving="false"] .QFrame {
-    border: 2px solid transparent;
-}
-
-TyphosBase TyphosPositionerWidget[moving="false"][successful_move="true"] .QFrame {
-    border: 2px solid green;
-}
-
-TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
-    border: 2px solid red;
-}
-
 SignalPanelRowLabel {
     font: 12px sans-serif;
 }

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1036</width>
-    <height>142</height>
+    <width>828</width>
+    <height>105</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>0</number>
+    <number>1</number>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -46,26 +46,68 @@
    </property>
    <item>
     <widget class="QFrame" name="row_frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>60</height>
+      </size>
+     </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>75</height>
+       <height>60</height>
       </size>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
        <number>3</number>
       </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item alignment="Qt::AlignBottom">
        <widget class="QPushButton" name="expand_button">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
-          <width>30</width>
-          <height>16777215</height>
+          <width>25</width>
+          <height>25</height>
          </size>
         </property>
         <property name="text">
          <string>&gt;</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -94,14 +136,29 @@
           <property name="toolTip">
            <string/>
           </property>
+          <property name="penWidth" stdset="0">
+           <double>1.000000000000000</double>
+          </property>
          </widget>
         </item>
         <item alignment="Qt::AlignVCenter">
          <widget class="QLabel" name="alarm_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>0</height>
+            <width>40</width>
+            <height>15</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>15</height>
            </size>
           </property>
           <property name="text">
@@ -128,7 +185,7 @@
         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
          <widget class="PyDMByteIndicator" name="moving_indicator">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -211,10 +268,22 @@
         </item>
         <item alignment="Qt::AlignVCenter">
          <widget class="QLabel" name="moving_indicator_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>0</height>
+            <width>40</width>
+            <height>15</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>15</height>
            </size>
           </property>
           <property name="text">
@@ -237,6 +306,24 @@
         </property>
         <item alignment="Qt::AlignVCenter">
          <widget class="QLabel" name="device_name_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>25</height>
+           </size>
+          </property>
           <property name="font">
            <font>
             <weight>75</weight>
@@ -261,7 +348,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>0</width>
+            <width>60</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
             <height>25</height>
            </size>
           </property>
@@ -298,7 +391,7 @@
         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
          <widget class="PyDMByteIndicator" name="low_limit_switch">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -355,10 +448,22 @@
         </item>
         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
          <widget class="PyDMLabel" name="low_limit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>0</height>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
           <property name="font">
@@ -373,107 +478,172 @@
            <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
           </property>
           <property name="text">
-           <string>low_limit</string>
+           <string>low</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
+          </property>
+          <property name="precision" stdset="0">
+           <number>1</number>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="setpoint_outer_layout">
-        <property name="spacing">
-         <number>0</number>
+       <widget class="QFrame" name="setpoint_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <item>
-         <layout class="QVBoxLayout" name="setpoint_layout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-           <widget class="PyDMLineEdit" name="user_setpoint">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>200</width>
-              <height>25</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="QWidget" name="tweak_widget" native="true">
-          <layout class="QHBoxLayout" name="tweak_layout" stretch="0,0,0">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>150</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QVBoxLayout" name="setpoint_outer_layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QVBoxLayout" name="setpoint_layout" stretch="0">
            <property name="spacing">
-            <number>3</number>
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
            </property>
            <property name="topMargin">
-            <number>1</number>
+            <number>0</number>
            </property>
-           <property name="bottomMargin">
-            <number>1</number>
+           <property name="rightMargin">
+            <number>0</number>
            </property>
-           <item alignment="Qt::AlignTop">
-            <widget class="QToolButton" name="tweak_negative">
+           <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+            <widget class="PyDMLineEdit" name="user_setpoint">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
-               <width>25</width>
-               <height>25</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>-</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="tweak_value">
-             <property name="minimumSize">
-              <size>
-               <width>60</width>
+               <width>100</width>
                <height>25</height>
               </size>
              </property>
              <property name="maximumSize">
               <size>
-               <width>200</width>
-               <height>16777215</height>
+               <width>100</width>
+               <height>25</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string/>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QToolButton" name="tweak_positive">
-             <property name="minimumSize">
-              <size>
-               <width>25</width>
-               <height>25</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>+</string>
-             </property>
-            </widget>
-           </item>
           </layout>
-         </widget>
-        </item>
-       </layout>
+         </item>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="QWidget" name="tweak_widget" native="true">
+           <layout class="QHBoxLayout" name="tweak_layout" stretch="0,0,0">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>1</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>1</number>
+            </property>
+            <item alignment="Qt::AlignTop">
+             <widget class="QToolButton" name="tweak_negative">
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>-</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="tweak_value">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="tweak_positive">
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>+</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <layout class="QVBoxLayout" name="high_limit_layout">
@@ -482,6 +652,12 @@
         </property>
         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
          <widget class="PyDMByteIndicator" name="high_limit_switch">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>25</width>
@@ -543,10 +719,22 @@
         </item>
         <item alignment="Qt::AlignVCenter">
          <widget class="PyDMLabel" name="high_limit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>0</height>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
           <property name="font">
@@ -561,10 +749,16 @@
            <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
           </property>
           <property name="text">
-           <string>high_limit</string>
+           <string>high</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
+          </property>
+          <property name="precision" stdset="0">
+           <number>1</number>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -573,21 +767,21 @@
       <item alignment="Qt::AlignVCenter">
        <widget class="QPushButton" name="stop_button">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>100</width>
-          <height>40</height>
+          <width>60</width>
+          <height>50</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>150</width>
-          <height>60</height>
+          <width>60</width>
+          <height>50</height>
          </size>
         </property>
         <property name="font">
@@ -615,16 +809,22 @@
       </item>
       <item alignment="Qt::AlignVCenter">
        <widget class="TyphosRelatedSuiteButton" name="expert_button">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="minimumSize">
          <size>
           <width>60</width>
-          <height>40</height>
+          <height>50</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
           <width>60</width>
-          <height>40</height>
+          <height>50</height>
          </size>
         </property>
         <property name="font">
@@ -661,36 +861,80 @@ Screen</string>
       </size>
      </property>
      <layout class="QVBoxLayout" name="status_text_layout">
-      <item alignment="Qt::AlignTop">
-       <widget class="QLabel" name="status_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>(Status label)</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="clear_error_layout">
-        <item alignment="Qt::AlignLeft">
+        <item>
+         <layout class="QVBoxLayout" name="inner_error">
+          <item>
+           <widget class="QLabel" name="status_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string> (Status label)</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="PyDMLabel" name="error_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>(Error label)</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="displayFormat" stdset="0">
+             <enum>PyDMLabel::String</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QPushButton" name="clear_error_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>25</height>
+            <width>100</width>
+            <height>35</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>100</width>
-            <height>25</height>
+            <height>35</height>
            </size>
           </property>
           <property name="font">
@@ -707,28 +951,6 @@ Screen</string>
           </property>
           <property name="text">
            <string>Clear Error</string>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignLeft">
-         <widget class="PyDMLabel" name="error_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="displayFormat" stdset="0">
-           <enum>PyDMLabel::String</enum>
           </property>
          </widget>
         </item>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>635</width>
-    <height>141</height>
+    <width>655</width>
+    <height>160</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>1</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -60,13 +60,13 @@
        <property name="minimumSize">
         <size>
          <width>60</width>
-         <height>30</height>
+         <height>35</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
          <width>16777215</width>
-         <height>30</height>
+         <height>35</height>
         </size>
        </property>
        <property name="font">
@@ -103,13 +103,13 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>60</height>
+       <height>64</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>60</height>
+       <height>64</height>
       </size>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
@@ -169,13 +169,13 @@
           <property name="minimumSize">
            <size>
             <width>50</width>
-            <height>15</height>
+            <height>25</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>50</width>
-            <height>15</height>
+            <height>25</height>
            </size>
           </property>
           <property name="text">
@@ -294,13 +294,13 @@
           <property name="minimumSize">
            <size>
             <width>50</width>
-            <height>15</height>
+            <height>25</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>50</width>
-            <height>15</height>
+            <height>25</height>
            </size>
           </property>
           <property name="text">
@@ -476,13 +476,13 @@
           <property name="minimumSize">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>25</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>25</height>
            </size>
           </property>
           <property name="font">
@@ -778,13 +778,13 @@
           <property name="minimumSize">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>25</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>25</height>
            </size>
           </property>
           <property name="font">
@@ -857,13 +857,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>50</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>50</height>
            </size>
           </property>
@@ -900,13 +900,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>0</height>
            </size>
           </property>
@@ -916,6 +916,9 @@
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <property name="leftMargin">
          <number>0</number>
         </property>
@@ -929,13 +932,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>50</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>50</height>
            </size>
           </property>
@@ -971,13 +974,13 @@ Screen</string>
           </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>60</width>
+            <width>70</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1061,13 +1064,13 @@ Screen</string>
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>19</height>
+              <height>25</height>
              </size>
             </property>
             <property name="maximumSize">
              <size>
               <width>16777215</width>
-              <height>19</height>
+              <height>25</height>
              </size>
             </property>
             <property name="styleSheet">
@@ -1103,13 +1106,13 @@ Screen</string>
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>19</height>
+                <height>25</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
                 <width>16777215</width>
-                <height>19</height>
+                <height>25</height>
                </size>
               </property>
               <property name="styleSheet">
@@ -1131,13 +1134,13 @@ Screen</string>
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>19</height>
+                <height>25</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
                 <width>16777215</width>
-                <height>19</height>
+                <height>25</height>
                </size>
               </property>
               <property name="toolTip">
@@ -1174,13 +1177,13 @@ Screen</string>
           </property>
           <property name="minimumSize">
            <size>
-            <width>123</width>
+            <width>143</width>
             <height>42</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>123</width>
+            <width>143</width>
             <height>42</height>
            </size>
           </property>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>828</width>
-    <height>105</height>
+    <height>136</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -44,6 +44,47 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item>
+    <widget class="QLabel" name="device_name_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>60</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>${name}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <property name="indent">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QFrame" name="row_frame">
      <property name="sizePolicy">
@@ -305,40 +346,6 @@
          <number>0</number>
         </property>
         <item alignment="Qt::AlignVCenter">
-         <widget class="QLabel" name="device_name_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>60</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>${name}</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignVCenter">
          <widget class="PyDMLabel" name="user_readback">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -349,14 +356,22 @@
           <property name="minimumSize">
            <size>
             <width>60</width>
-            <height>25</height>
+            <height>45</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
-            <height>25</height>
+            <height>45</height>
            </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>18</pointsize>
+            <weight>50</weight>
+            <italic>false</italic>
+            <bold>false</bold>
+           </font>
           </property>
           <property name="toolTip">
            <string/>
@@ -365,7 +380,7 @@
            <string/>
           </property>
           <property name="styleSheet">
-           <string notr="true"/>
+           <string notr="true">font: 18pt</string>
           </property>
           <property name="text">
            <string>user_readback</string>
@@ -478,7 +493,7 @@
            <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
           </property>
           <property name="text">
-           <string>low</string>
+           <string/>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -749,7 +764,7 @@
            <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
           </property>
           <property name="text">
-           <string>high</string>
+           <string/>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -905,7 +920,7 @@ Screen</string>
              <string/>
             </property>
             <property name="text">
-             <string>(Error label)</string>
+             <string/>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>828</width>
-    <height>136</height>
+    <width>635</width>
+    <height>141</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -45,45 +45,52 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="device_name_label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>60</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>${name}</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="margin">
+    <layout class="QHBoxLayout" name="device_name_layout">
+     <property name="topMargin">
       <number>0</number>
      </property>
-     <property name="indent">
-      <number>30</number>
-     </property>
-    </widget>
+     <item>
+      <widget class="QLabel" name="device_name_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>60</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>${name}</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QFrame" name="row_frame">
@@ -121,37 +128,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item alignment="Qt::AlignBottom">
-       <widget class="QPushButton" name="expand_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>25</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>25</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>&gt;</string>
-        </property>
-        <property name="checkable">
-         <bool>false</bool>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
       <item>
        <layout class="QVBoxLayout" name="alarm_layout">
         <property name="spacing">
@@ -164,14 +140,14 @@
          <widget class="TyphosAlarmRectangle" name="alarm_circle">
           <property name="minimumSize">
            <size>
-            <width>25</width>
-            <height>25</height>
+            <width>30</width>
+            <height>30</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>25</width>
-            <height>25</height>
+            <width>30</width>
+            <height>30</height>
            </size>
           </property>
           <property name="toolTip">
@@ -192,13 +168,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>40</width>
+            <width>50</width>
             <height>15</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>40</width>
+            <width>50</width>
             <height>15</height>
            </size>
           </property>
@@ -233,14 +209,14 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>25</width>
-            <height>25</height>
+            <width>30</width>
+            <height>30</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>25</width>
-            <height>25</height>
+            <width>30</width>
+            <height>30</height>
            </size>
           </property>
           <property name="toolTip">
@@ -263,7 +239,7 @@
            <bool>false</bool>
           </property>
           <property name="alarmSensitiveBorder" stdset="0">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="PyDMToolTip" stdset="0">
            <string/>
@@ -317,13 +293,13 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>40</width>
+            <width>50</width>
             <height>15</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>40</width>
+            <width>50</width>
             <height>15</height>
            </size>
           </property>
@@ -335,6 +311,28 @@
           </property>
           <property name="wordWrap">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_4" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
           </property>
          </widget>
         </item>
@@ -355,19 +353,19 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>60</width>
-            <height>45</height>
+            <width>150</width>
+            <height>35</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
-            <height>45</height>
+            <height>35</height>
            </size>
           </property>
           <property name="font">
            <font>
-            <pointsize>18</pointsize>
+            <pointsize>16</pointsize>
             <weight>50</weight>
             <italic>false</italic>
             <bold>false</bold>
@@ -380,16 +378,19 @@
            <string/>
           </property>
           <property name="styleSheet">
-           <string notr="true">font: 18pt</string>
+           <string notr="true">font: 16pt</string>
           </property>
           <property name="text">
            <string>user_readback</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignCenter</set>
           </property>
           <property name="showUnits" stdset="0">
            <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -438,6 +439,9 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
           </property>
           <property name="onColor" stdset="0">
            <color>
@@ -503,6 +507,31 @@
           </property>
           <property name="precisionFromPV" stdset="0">
            <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
           </property>
          </widget>
         </item>
@@ -583,6 +612,9 @@
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
+             </property>
+             <property name="alarmSensitiveBorder" stdset="0">
+              <bool>false</bool>
              </property>
             </widget>
            </item>
@@ -704,6 +736,9 @@
           <property name="styleSheet">
            <string notr="true">margin: 0px;</string>
           </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
+          </property>
           <property name="onColor" stdset="0">
            <color>
             <red>239</red>
@@ -775,94 +810,180 @@
           <property name="precisionFromPV" stdset="0">
            <bool>false</bool>
           </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_3" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item alignment="Qt::AlignVCenter">
-       <widget class="QPushButton" name="stop_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>0</number>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
+        <property name="leftMargin">
+         <number>0</number>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
-        </property>
-        <property name="text">
-         <string>Stop</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-        <property name="default">
-         <bool>false</bool>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
+        <item>
+         <widget class="QPushButton" name="stop_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
+          </property>
+          <property name="text">
+           <string>Stop</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+          <property name="default">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_5" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item alignment="Qt::AlignVCenter">
-       <widget class="TyphosRelatedSuiteButton" name="expert_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="leftMargin">
+         <number>0</number>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="styleSheet">
-         <string notr="true"/>
-        </property>
-        <property name="text">
-         <string>Expert
+        <item>
+         <widget class="TyphosRelatedSuiteButton" name="expert_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <property name="text">
+           <string>Expert
 Screen</string>
-        </property>
-        <property name="icon">
-         <iconset theme="gear">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
+          </property>
+          <property name="icon">
+           <iconset theme="gear">
+            <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_6" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -891,14 +1012,66 @@ Screen</string>
       <item>
        <layout class="QHBoxLayout" name="clear_error_layout">
         <item>
+         <widget class="QPushButton" name="expand_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Expand Details</string>
+          </property>
+          <property name="text">
+           <string>&gt;</string>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QVBoxLayout" name="inner_error">
-          <item>
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <item alignment="Qt::AlignVCenter">
            <widget class="QLabel" name="status_label">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>19</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>19</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
             </property>
             <property name="text">
              <string> (Status label)</string>
@@ -906,29 +1079,88 @@ Screen</string>
             <property name="wordWrap">
              <bool>true</bool>
             </property>
+            <property name="indent">
+             <number>0</number>
+            </property>
            </widget>
           </item>
           <item>
-           <widget class="PyDMLabel" name="error_label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="spacing">
+             <number>0</number>
             </property>
-            <property name="toolTip">
-             <string/>
+            <property name="topMargin">
+             <number>0</number>
             </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="displayFormat" stdset="0">
-             <enum>PyDMLabel::String</enum>
-            </property>
-           </widget>
+            <item>
+             <widget class="QLabel" name="error_prefix">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>19</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>19</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: red</string>
+              </property>
+              <property name="text">
+               <string>Error: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="error_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>19</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>19</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="indent">
+               <number>0</number>
+              </property>
+              <property name="displayFormat" stdset="0">
+               <enum>PyDMLabel::String</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
@@ -942,14 +1174,14 @@ Screen</string>
           </property>
           <property name="minimumSize">
            <size>
-            <width>100</width>
-            <height>35</height>
+            <width>123</width>
+            <height>42</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>100</width>
-            <height>35</height>
+            <width>123</width>
+            <height>42</height>
            </size>
           </property>
           <property name="font">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- shorter text in positioner row alarm label
- status container always visible
- dynamic showing/hiding of status info
- infinite arrangement/sizing/size policy nitpicking
- drop the concept of the whole widget getting a colored border during/after moves
- no alarm borders inside the widget
- add some more accurate placeholder templates for twincat states things

edited to add:
- remove typhos stylesheet for the error pydm label widget